### PR TITLE
Fix RH config location

### DIFF
--- a/dhcpd/map.jinja
+++ b/dhcpd/map.jinja
@@ -7,6 +7,6 @@
     'RedHat': {
         'server': 'dhcp',
         'service': 'dhcpd',
-        'config': '/etc/dhcpd.conf',
+        'config': '/etc/dhcp/dhcpd.conf',
     },
 }, merge=salt['pillar.get']('dhcpd:lookup')) %}


### PR DESCRIPTION
RH config is in /etc/dhcp/dhcpd.conf, not /etc/dhcpd.conf as previously set.