### PR TITLE
Add host-name option to client configuration

### DIFF
--- a/dhcpd/files/dhcpd.conf
+++ b/dhcpd/files/dhcpd.conf
@@ -65,6 +65,9 @@ host {{ host }} {
   {%- if config.has_key('server_name') %}
   server-name "{{ config.server_name }}";
   {%- endif %}
+  {%- if config.has_key('host_name') %}
+  option host-name "{{ config.host_name }}";
+  {%- endif %}
 }
 {% endfor %}
 {%- for class, config in salt['pillar.get']('dhcpd:classes', {}).items() %}

--- a/pillar.example
+++ b/pillar.example
@@ -75,6 +75,14 @@ dhcpd:
             hardware: ethernet 08:00:07:26:c0:a5
             fixed_address: fantasia.fugue.com
 
+        joe:
+            comment: |
+                The hostname for a host can be passed in the DHCP response. Using the
+                host_name key sets option host-name in the dhcpd configuration.
+            hardware: ethernet 08:00:2b:4c:29:32
+            fixed_address: joe.fugue.com
+            host_name: joe
+
     classes:
         foo:
             comment: |


### PR DESCRIPTION
This PR adds the host-name option for DHCP client requests