### PR TITLE
Add support for several config options

### DIFF
--- a/dhcpd/files/dhcpd.conf
+++ b/dhcpd/files/dhcpd.conf
@@ -60,9 +60,21 @@ use-host-decl-names on;
 {%- endif %}
 
 {%- if salt['pillar.get']('dhcpd:allow', False) %}
-allow {{ salt['pillar.get']('dhcpd:allow') }};
-{%- elif salt['pillar.get']('dhcpd:deny', False) %}
-deny {{ salt['pillar.get']('dhcpd:deny') }};
+  {%- set allow = salt['pillar.get']('dhcpd:allow') %}
+  {%- if allow is iterable and allow is not string %}
+    {%- for item in allow %}allow {{ item }};{%- endfor %}
+  {%- else %}allow {{ allow }};
+  {%- endif %}
+{%- endif %}
+
+{%- if salt['pillar.get']('dhcpd:deny', False) %}
+  {%- set deny = salt['pillar.get']('dhcpd:deny') %}
+  {%- if deny is iterable and deny is not string %}
+    {%- for item in deny %}
+deny {{ item }};
+{%- endfor %}
+  {%- else %}deny {{ deny }};
+  {%- endif %}
 {%- endif %}
 
 # Use this to enble / disable dynamic dns updates globally.
@@ -172,9 +184,14 @@ failover peer "{{ failover_peer }}" {
   {%- endif %}
 host {{ host }} {
   {%- if config.has_key('allow') %}
-  allow {{ config.allow }};
-  {%- elif config.has_key('deny') %}
-  deny {{ config.deny }};
+    {%- if config.allow is iterable and config.allow is not string %}
+      {%- for item in config.allow %}allow {{ item }};{%- endfor %}
+    {%- else %}allow {{ config.allow }};{%- endif %}
+  {%- endif %}
+  {%- if config.has_key('deny') %}
+    {%- if config.deny is iterable and config.deny is not string %}
+      {%- for item in config.deny %}deny {{ item }};{%- endfor %}
+    {%- else %}deny {{ config.deny }};{%- endif %}
   {%- endif %}
   {%- if config.has_key('hardware') %}
   hardware {{ config.hardware }};

--- a/dhcpd/files/dhcpd.conf
+++ b/dhcpd/files/dhcpd.conf
@@ -172,6 +172,28 @@ failover peer "{{ failover_peer }}" {
 {%- endfor %}
 
 {%- set intendation='' %}
+{%- for key, config in salt['pillar.get']('dhcpd:keys', {}).items() %}
+key {{ key }} {
+  {%- if config.has_key('algorithm') %}
+  algorithm {{ config.algorithm }};
+  {%- endif %}
+  {%- if config.has_key('secret') %}
+  secret {{ config.secret }};
+  {%- endif %}
+}
+{%- endfor %}
+
+{%- for zone, config in salt['pillar.get']('dhcpd:zones', {}).items() %}
+zone {{ zone }} {
+  {%- if config.has_key('primary') %}
+  primary {{ config.primary }};
+  {%- endif %}
+  {%- if config.has_key('key') %}
+  key {{ config.key }};
+  {%- endif %}
+}
+{%- endfor %}
+
 {%- for subnet, config in salt['pillar.get']('dhcpd:subnets', {}).items() %}
 {%- include 'dhcpd/files/subnet.jinja' with context %}
 {%- endfor %}

--- a/dhcpd/files/dhcpd.conf
+++ b/dhcpd/files/dhcpd.conf
@@ -3,10 +3,10 @@
 # SaltStack-generated configuration file for ISC dhcpd
 #
 
-{% set customized = {} %}
-{% set types_to_quote = ['string', 'text'] %}
-{% set quote = '' %}
-{% set dquote = '"' %}
+{%- set customized = {} %}
+{%- set types_to_quote = ['string', 'text'] %}
+{%- set quote = '' %}
+{%- set dquote = '"' %}
 {% if salt['pillar.get']('dhcpd:customized_options', False) -%}
 {%- set customized = salt['pillar.get']('dhcpd:customized_options', {}) %}
 # Customized dhcp options

--- a/dhcpd/files/dhcpd.conf
+++ b/dhcpd/files/dhcpd.conf
@@ -22,7 +22,16 @@ option domain-name "{{ salt['pillar.get']('dhcpd:domain_name') }}";
 {% if salt['pillar.get']('dhcpd:domain_name_servers', False) -%}
 option domain-name-servers
   {%- for dns_server in salt['pillar.get']('dhcpd:domain_name_servers') %} {{ dns_server }}
-    {%- if not loop.last %}, {% else %};{% endif %}
+    {%- if not loop.last %},{% else %};{% endif %}
+  {%- endfor %}
+{% endif -%}
+{% if salt['pillar.get']('dhcpd:subnet_mask', False) -%}
+option subnet-mask "{{ salt['pillar.get']('dhcpd:subnet_mask') }}";
+{% endif -%}
+{% if salt['pillar.get']('dhcpd:routers', False) -%}
+option routers
+  {%- for router in salt['pillar.get']('dhcpd:routers') %} {{ router }}
+    {%- if not loop.last %},{% else %};{% endif %}
   {%- endfor %}
 {% endif -%}
 
@@ -44,21 +53,33 @@ server-identifier {{ salt['pillar.get']('dhcpd:server_identifier') }};
 {% if salt['pillar.get']('dhcpd:server_name') -%}
 server-name {{ dquote }}{{ salt['pillar.get']('dhcpd:server_name') }}{{ dquote }};
 {% endif -%}
+{%- if salt['pillar.get']('dhcpd:use_host_decl_names', False) %}
+use-host-decl-names on;
+{%- else %}
+#use-host-decl-names off;
+{%- endif %}
+
 {%- if salt['pillar.get']('dhcpd:allow', False) %}
 allow {{ salt['pillar.get']('dhcpd:allow') }};
 {%- elif salt['pillar.get']('dhcpd:deny', False) %}
 deny {{ salt['pillar.get']('dhcpd:deny') }};
 {%- endif %}
-{%- if 'use_host_decl_names' in salt['pillar.get']('dhcpd', {}) %}
-use-host-decl-names {{ salt['pillar.get']('dhcpd:use_host_decl_names') }};
-{%- endif %}
-
 
 # Use this to enble / disable dynamic dns updates globally.
 {%- if salt['pillar.get']('dhcpd:ddns_update_style', False) %}
 ddns-update-style {{ salt['pillar.get']('dhcpd:ddns_update_style') }};
 {%- else %}
 #ddns-update-style none;
+{%- endif %}
+
+{%- if salt['pillar.get']('dhcpd:ddns_domainname', '') %}
+ddns-domainname "{{ salt['pillar.get']('dhcpd:ddns_domainname') }}";
+{%- endif %}
+
+{%- if salt['pillar.get']('dhcpd:update_static_leases', False) %}
+update-static-leases on;
+{%- else %}
+#update-static-leases off;
 {%- endif %}
 
 # If this DHCP server is the official DHCP server for the local

--- a/dhcpd/files/dhcpd.conf
+++ b/dhcpd/files/dhcpd.conf
@@ -26,7 +26,7 @@ option domain-name-servers
   {%- endfor %}
 {% endif -%}
 {% if salt['pillar.get']('dhcpd:subnet_mask', False) -%}
-option subnet-mask "{{ salt['pillar.get']('dhcpd:subnet_mask') }}";
+option subnet-mask {{ salt['pillar.get']('dhcpd:subnet_mask') }};
 {% endif -%}
 {% if salt['pillar.get']('dhcpd:routers', False) -%}
 option routers

--- a/dhcpd/files/subnet.jinja
+++ b/dhcpd/files/subnet.jinja
@@ -79,9 +79,9 @@
 {{ intendation }}    range {{ pool.range[0] }} {{ pool.range[1] }};
     {%- endif %}
     {%- if pool.has_key('allow') %}
-{{ intendation }}  allow {{ pool.allow }};
+{{ intendation }}    allow {{ pool.allow }};
     {%- elif pool.has_key('deny') %}
-{{ intendation }}  deny {{ pool.deny }};
+{{ intendation }}    deny {{ pool.deny }};
     {%- endif %}
 {{ intendation }}  }
 {%- endfor %}

--- a/dhcpd/files/subnet.jinja
+++ b/dhcpd/files/subnet.jinja
@@ -4,11 +4,6 @@
   {%- endfor %}
 {%- endif %}
 {{ intendation }}subnet {{ subnet }} netmask {{ config.netmask }} {
-{%- if config.has_key('allow') %}
-{{ intendation }}  allow {{ config.allow }};
-{%- elif config.has_key('deny') %}
-{{ intendation }}  deny {{ config.deny }};
-{%- endif %}
 {%- if 'use_host_decl_names' in config %}
 {{ intendation }}  use-host-decl-names {{ config.use_host_decl_names }};
 {%- endif %}
@@ -82,6 +77,11 @@
     {%- endif %}
     {%- if pool.has_key('range') %}
 {{ intendation }}    range {{ pool.range[0] }} {{ pool.range[1] }};
+    {%- endif %}
+    {%- if pool.has_key('allow') %}
+{{ intendation }}  allow {{ pool.allow }};
+    {%- elif pool.has_key('deny') %}
+{{ intendation }}  deny {{ pool.deny }};
     {%- endif %}
 {{ intendation }}  }
 {%- endfor %}


### PR DESCRIPTION
New:

- key
- router
- update-static-leases
- subnet-mask
- ddns-domainname
- use-host-decl-names

Updated:

- allow/deny - Allow passing an array of values like so:
```
  deny:
    - bootp
    - client-updates
    - declines
    - leasequery
```