### PR TITLE
Change in Debian Strech

### DIFF
--- a/dhcpd/files/service_config.Debian
+++ b/dhcpd/files/service_config.Debian
@@ -12,4 +12,8 @@
 
 # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
 #       Separate multiple interfaces with spaces, e.g. "eth0 eth1".
+{% if grains.osmajorrelease >= 9 %}
+INTERFACESv4="{{ ' '.join(salt['pillar.get']('dhcpd:listen_interfaces', [])) }}"
+{% else %}
 INTERFACES="{{ ' '.join(salt['pillar.get']('dhcpd:listen_interfaces', [])) }}"
+{% endif %}


### PR DESCRIPTION
Debian Notes : isc-dhcp-server: fails to work, variable INTERFACES in /etc/default/isc-dhcp-server has been split into INTERFACESv4 and INTERFACESv6.

simple patch to ipv4, it should be better to add INTERFACESv6, but I think there is more modifications to do than this little change for ipv6...