### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -1,153 +1,156 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 dhcpd:
-    # Change some defaults
-    lookup:
-      enable: False
+  # Change some defaults
+  lookup:
+    enable: false
 
-    domain_name: example.org
-    domain_name_servers:
-        - ns1.example.org
-        - ns2.example.org
-    default_lease_time: 600
-    max_lease_time: 7200
-    log_facility: local7
-    failover_peers:
-        dhcp-failover:
-            primary: true
-            address: 10.152.187.5
-            port: 647
-            peer_address: 10.152.187.6
-            peer_port: 647
-            split: 128
-            mclt: 3600
-    listen_interfaces:
-        - em1
-        - em2
-    subnets:
-        10.152.187.0:
-            comment: |
-                No service will be given on this subnet, but declaring it helps the
-                DHCP server to understand the network topology.
-            netmask: 255.255.255.0
-            pools:
-                - failover_peer: dhcp-failover
-                  range:
-                      - 10.152.187.1
-                      - 10.152.187.254
+  domain_name: example.org
+  domain_name_servers:
+    - ns1.example.org
+    - ns2.example.org
+  default_lease_time: 600
+  max_lease_time: 7200
+  log_facility: local7
+  failover_peers:
+    dhcp-failover:
+      primary: true
+      address: 10.152.187.5
+      port: 647
+      peer_address: 10.152.187.6
+      peer_port: 647
+      split: 128
+      mclt: 3600
+  listen_interfaces:
+    - em1
+    - em2
+  subnets:
+    10.152.187.0:
+      comment: |
+        No service will be given on this subnet, but declaring it helps the
+        DHCP server to understand the network topology.
+      netmask: 255.255.255.0
+      pools:
+        - failover_peer: dhcp-failover
+          range:
+            - 10.152.187.1
+            - 10.152.187.254
 
-        10.254.239.0:
-            comment: This is a very basic subnet declaration.
-            netmask: 255.255.255.224
-            range:
-                - 10.254.239.10
-                - 10.254.239.20
-            routers:
-                - rtr-239-0-1.example.org
-                - rtr-239-0-2.example.org
+    10.254.239.0:
+      comment: This is a very basic subnet declaration.
+      netmask: 255.255.255.224
+      range:
+        - 10.254.239.10
+        - 10.254.239.20
+      routers:
+        - rtr-239-0-1.example.org
+        - rtr-239-0-2.example.org
 
-        10.254.239.32:
-            comment: |
-                This declaration allows BOOTP clients to get dynamic addresses,
-                which we don't really recommend.
-            netmask: 255.255.255.224
-            dynamic_bootp: True
-            range:
-                - 10.254.239.40
-                - 10.254.239.60
-            broadcast_address: 10.254.239.31
-            routers: rtr-239-32-1.example.org
+    10.254.239.32:
+      comment: |
+        This declaration allows BOOTP clients to get dynamic addresses,
+        which we don't really recommend.
+      netmask: 255.255.255.224
+      dynamic_bootp: true
+      range:
+        - 10.254.239.40
+        - 10.254.239.60
+      broadcast_address: 10.254.239.31
+      routers: rtr-239-32-1.example.org
 
-        10.5.5.0:
-            comment: A slightly different configuration for an internal subnet.
-            netmask: 255.255.255.224
-            range:
-                - 10.5.5.26
-                - 10.5.5.30
-            domain_name_servers:
-                - ns1.internal.example.org
-            domain_name: internal.example.org
-            routers:
-                - 10.5.5.1
-            broadcast_address: 10.5.5.31
-            default_lease_time: 600
-            max_lease_time: 7200
-            hosts:
-                jake:
-                    comment: |
-                        Hosts can be specified for subnets, taking subnets defaults
-                    hardware: ethernet 08:00:a7:26:c0:a9
-                    fixed_address: 10.5.5.27
+    10.5.5.0:
+      comment: A slightly different configuration for an internal subnet.
+      netmask: 255.255.255.224
+      range:
+        - 10.5.5.26
+        - 10.5.5.30
+      domain_name_servers:
+        - ns1.internal.example.org
+      domain_name: internal.example.org
+      routers:
+        - 10.5.5.1
+      broadcast_address: 10.5.5.31
+      default_lease_time: 600
+      max_lease_time: 7200
+      hosts:
+        jake:
+          comment: |
+            Hosts can be specified for subnets, taking subnets defaults
+          hardware: ethernet 08:00:a7:26:c0:a9
+          fixed_address: 10.5.5.27
 
-    # End of subnets
+  # End of subnets
 
-    hosts:
-        passacaglia:
-            comment: |
-                Hosts which require special configuration options can be listed in
-                host statements.   If no address is specified, the address will be
-                allocated dynamically (if possible), but the host-specific information
-                will still come from the host declaration.
-            # We're lucky we don't need the MAC as a key...
-            hardware: ethernet 0:0:c0:5d:bd:95
-            filename: vmunix.passacaglia
-            server_name: toccata.fugue.com
+  hosts:
+    passacaglia:
+      comment: |
+        Hosts which require special configuration options can be listed in
+        host statements.  If no address is specified, the address will be
+        allocated dynamically (if possible), but the host-specific information
+        will still come from the host declaration.
+      # We're lucky we don't need the MAC as a key...
+      hardware: ethernet 0:0:c0:5d:bd:95
+      filename: vmunix.passacaglia
+      server_name: toccata.fugue.com
 
-        fantasia:
-            comment: |
-                Fixed IP addresses can also be specified for hosts.   These addresses
-                should not also be listed as being available for dynamic assignment.
-                Hosts for which fixed IP addresses have been specified can boot using
-                BOOTP or DHCP.   Hosts for which no fixed address is specified can only
-                be booted with DHCP, unless there is an address range on the subnet
-                to which a BOOTP client is connected which has the dynamic-bootp flag
-                set.
-            hardware: ethernet 08:00:07:26:c0:a5
-            fixed_address: fantasia.fugue.com
+    fantasia:
+      comment: |
+        Fixed IP addresses can also be specified for hosts.  These addresses
+        should not also be listed as being available for dynamic assignment.
+        Hosts for which fixed IP addresses have been specified can boot using
+        BOOTP or DHCP.  Hosts for which no fixed address is specified can only
+        be booted with DHCP, unless there is an address range on the subnet
+        to which a BOOTP client is connected which has the dynamic-bootp flag
+        set.
+      hardware: ethernet 08:00:07:26:c0:a5
+      fixed_address: fantasia.fugue.com
 
-        joe:
-            comment: |
-                The hostname for a host can be passed in the DHCP response. Using the
-                host_name key sets option host-name in the dhcpd configuration.
-            hardware: ethernet 08:00:2b:4c:29:32
-            fixed_address: joe.fugue.com
-            host_name: joe
+    joe:
+      comment: |
+        The hostname for a host can be passed in the DHCP response. Using the
+        host_name key sets option host-name in the dhcpd configuration.
+      hardware: ethernet 08:00:2b:4c:29:32
+      fixed_address: joe.fugue.com
+      host_name: joe
 
-    classes:
-        foo:
-            comment: |
-                You can declare a class of clients and then do address allocation
-                based on that.   The example below shows a case where all clients
-                in a certain class get addresses on the 10.17.224/24 subnet, and all
-                other clients get addresses on the 10.0.29/24 subnet.
-            # I'm suprised this works...
-            match: if substring (option vendor-class-identifier, 0, 4) = "SUNW"
+  classes:
+    foo:
+      comment: |
+        You can declare a class of clients and then do address allocation
+        based on that.  The example below shows a case where all clients
+        in a certain class get addresses on the 10.17.224/24 subnet, and all
+        other clients get addresses on the 10.0.29/24 subnet.
+      # I'm suprised this works...
+      match: if substring (option vendor-class-identifier, 0, 4) = "SUNW"
 
-    shared_networks:
-        224-29:
-            subnets:
-                10.17.224.0:
-                    netmask: 255.255.255.0
-                    routers: rtr-224.example.org
-                10.0.29.0:
-                    netmask: 255.255.255.0
-                    routers: rtr-29.example.org
-            pools:
-                # And no, those quotation marks won't get stripped:
-                - allow: members of "foo"
-                  range:
-                    - 10.17.224.10
-                    - 10.17.224.250
-                - deny: members of "foo"
-                  range:
-                    - 10.0.29.10
-                    - 10.0.29.230
+  shared_networks:
+    224-29:
+      subnets:
+        10.17.224.0:
+          netmask: 255.255.255.0
+          routers: rtr-224.example.org
+        10.0.29.0:
+          netmask: 255.255.255.0
+          routers: rtr-29.example.org
+      pools:
+        # And no, those quotation marks won't get stripped:
+        - allow: members of "foo"
+          range:
+            - 10.17.224.10
+            - 10.17.224.250
+        - deny: members of "foo"
+          range:
+            - 10.0.29.10
+            - 10.0.29.230
 
-    # DHCP allow customized options, which, once declared, can be used as same as the default options
-    # on every level, e.g. as global or subnet option.
-    # These options will be declared on top of dhcpd.conf.
-    # They consist of a NAME (Attention! '_' will be replaced by '-'), a CODE number
-    # and a DATATYPE (e.g. string, text, integer, ip-address)
-    customized_options:
-        # unique option name, e.g. 'auto_proxy_config' will be 'auto-proxy-config'
-        auto_proxy_config:
-            code: 252
-            type: string
+  # DHCP allow customized options, which, once declared, can be used as same
+  # as the default options on every level, e.g. as global or subnet option.
+  # These options will be declared on top of dhcpd.conf.
+  # They consist of a NAME (Attention! '_' will be replaced by '-'), a CODE
+  # number and a DATATYPE (e.g. string, text, integer, ip-address)
+  customized_options:
+    # unique option name, e.g. 'auto_proxy_config' will be 'auto-proxy-config'
+    auto_proxy_config:
+      code: 252
+      type: string

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: dhcpd formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
dhcpd-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
pillar.example
  1:1       warning  missing document start "---"  (document-start)
  4:7       error    wrong indentation: expected 8 but found 6  (indentation)
  4:15      warning  truthy value should be one of [false, true]  (truthy)
  52:28     warning  truthy value should be one of [false, true]  (truthy)
  137:21    error    wrong indentation: expected 22 but found 20  (indentation)
  141:21    error    wrong indentation: expected 22 but found 20  (indentation)
  144:89    error    line too long (101 > 88 characters)  (line-length)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.