### PR TITLE
Add Red Hat styled service configuration

### DIFF
--- a/dhcpd/files/service_config.RedHat
+++ b/dhcpd/files/service_config.RedHat
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd --no-pid {{ ' '.join(salt['pillar.get']('dhcpd:listen_interfaces', [])) }}

--- a/dhcpd/map.jinja
+++ b/dhcpd/map.jinja
@@ -14,6 +14,7 @@
         'server': 'dhcp',
         'service': 'dhcpd',
         'config': '/etc/dhcp/dhcpd.conf',
+        'service_config': '/etc/systemd/system/dhcpd.service.d/override.conf',
     },
     'FreeBSD': {
         'server': 'isc-dhcp43-server',


### PR DESCRIPTION
Allow listening_interfaces on Red Hat family systems as well.
As these are by now using systemd, a systemd override file is installed
in /etc/systemd/system/dhcpd.service.d/override.conf defining the interface
list.